### PR TITLE
Refactor CREATE INDEX queries to match the naming convention

### DIFF
--- a/Client/Client/QUERIES.sql
+++ b/Client/Client/QUERIES.sql
@@ -38,8 +38,8 @@ INSERT INTO marks (StudID, DiscID, Mark) values (1, 'DS', 9);
 
 
 # Index
-CREATE INDEX idx_StudID ON marks (StudID);
-CREATE INDEX idx_StudIDMark ON marks (StudID,Mark);
+CREATE INDEX idx_marks_StudID ON marks (StudID);
+CREATE INDEX idx_marks_StudIDMark ON marks (StudID,Mark);
 
 
 # Delete


### PR DESCRIPTION
Convention: idx_TABLE-NAME_KEYS-NAMES
- When creating an index, it should contain the table name and key names, like the indexes that are created on CREATE TABLE with unique keys.

- Also removed useless KV files functions.
- Removed related KV files comments.
- Updated queries.