### PR TITLE
Fix insert when fk value was not equal to insert key value

### DIFF
--- a/Client/Client/QUERIES.sql
+++ b/Client/Client/QUERIES.sql
@@ -30,6 +30,7 @@ CREATE TABLE students (StudID INT PRIMARY KEY, GroupID INT REFERENCES groups (Gr
 INSERT INTO students (StudID, GroupID, StudName, Email) VALUES (1, 531, 'John Foreman', 'JohnForeman@email.com');
 INSERT INTO students (StudID, GroupID, StudName, Email) VALUES (2, 531, 'Ashley Cole', 'AshleyCole@email.com');
 INSERT INTO students (StudID, GroupID, StudName, Email) VALUES (3, 532, 'Nicolas Pitt', 'NicolasPitt@email.com');
+INSERT INTO students (StudID, GroupID, StudName, Email) VALUES (4, 532, 'John Doe', 'JohnDoe@email.com');
 
 
 # Marks

--- a/Server/Server/Server.cs
+++ b/Server/Server/Server.cs
@@ -284,22 +284,20 @@ namespace Server {
         }
 
         public static bool insertDataIntoIdxCollection(string collection, KeyValuePair<string, string> attribute, string pk, List<string> UKs) {
-            List<Record> records = mongoDBService.getAll(currentDatabase, collection);
+            List<Record> records = mongoDBService.getAllByKey(currentDatabase, collection, attribute.Value);
             if (records.Count() > 0) {
                 foreach (Record record in records) {
-                    if (record.key == attribute.Value) {
-                        if (UKs.Contains(attribute.Key)) {
-                            send(new Message(MessageAction.ERROR, "Cheia '" + attribute.Key + "' este cheie unica si exista deja valoarea '" + attribute.Value + "' in tabela '" + collection + "'."));
-                            return false;
-                        }
-
-                        mongoDBService.update(
-                            currentDatabase,
-                            collection,
-                            attribute.Value,
-                            string.Join("#", record.value, pk)
-                        );
+                    if (UKs.Contains(attribute.Key)) {
+                        send(new Message(MessageAction.ERROR, "Cheia '" + attribute.Key + "' este cheie unica si exista deja valoarea '" + attribute.Value + "' in tabela '" + collection + "'."));
+                        return false;
                     }
+
+                    mongoDBService.update(
+                        currentDatabase,
+                        collection,
+                        attribute.Value,
+                        string.Join("#", record.value, pk)
+                    );
                 }
             } else {
                 mongoDBService.insert(


### PR DESCRIPTION
Fixes this bug:

Index on GroupID:
INSERT INTO students (StudID, GroupID, StudName, Email) VALUES (1, 531, 'John Foreman', 'JohnForeman@email.com'); - working
INSERT INTO students (StudID, GroupID, StudName, Email) VALUES (2, 531, 'Ashley Cole', 'AshleyCole@email.com'); - working
INSERT INTO students (StudID, GroupID, StudName, Email) VALUES (3, 532, 'Nicolas Pitt', 'NicolasPitt@email.com'); - not working, adding only students collection